### PR TITLE
Support sub-millisecond timings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-statsd "0.3.11"
+(defproject crashlytics/clj-statsd "0.4.0"
   :description "statsd protocol client"
-  :url         "https://github.com/pyr/clj-statsd"
-  :dependencies [[org.clojure/clojure "1.4.0"]])
+  :url         "https://github.com/crashlytics/clj-statsd"
+  :dependencies [[org.clojure/clojure "1.7.0"]])

--- a/src/clj_statsd.clj
+++ b/src/clj_statsd.clj
@@ -30,7 +30,7 @@
     (catch Exception e
       socket)))
 
-(defn send-stat 
+(defn send-stat
   "Send a raw metric over the network."
   [^String content]
   (when-let [packet (try
@@ -64,7 +64,7 @@
 (defn timing
   "Time an event at specified rate, defaults to 1.0 rate"
   ([k v]      (timing k v 1.0))
-  ([k v rate] (publish (format "%s:%d|ms" (name k) v) rate)))
+  ([k v rate] (publish (format "%s:%s|ms" (name k) v) rate)))
 
 (defn decrement
   "Decrement a counter at specified rate, defaults to a one decrement
@@ -87,9 +87,9 @@
 (defmacro with-sampled-timing
   "Time the execution of the provided code, with sampling."
   [k rate & body]
-  `(let [start# (System/currentTimeMillis)
+  `(let [start# (System/nanoTime)
          result# (do ~@body)]
-    (timing ~k (- (System/currentTimeMillis) start#) ~rate)
+    (timing ~k (/ (- (System/nanoTime) start#) 1000000) ~rate)
     result#))
 
 (defmacro with-timing


### PR DESCRIPTION
- Timings can be sent as floating point values (here as raw strings),
  not only as decimals.
- Use `System/nanoTime` in `with-sampled-timing` & `with-timing`
  nanoTime should provide greater sub-millisecond accuracy
